### PR TITLE
update installation instructions and tests to use 'ddev add-on get'

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,17 @@ YouTube: [Bun 1.0 is here](https://www.youtube.com/watch?v=BsnCpESUEqM)
 
 ## Installation
 
-```
-ddev get Morgy93/ddev-bun
+```shell
+ddev add-on get Morgy93/ddev-bun
 ddev restart
 ```
 
+> [!NOTE]
+> For DDEV versions prior to v1.23.5, use `ddev get` instead of `ddev add-on get`.
+
 ## Usage
 
-```
+```shell
 ddev bun
 ```
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -26,8 +26,8 @@ teardown() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR}
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR}
   ddev restart
   health_checks
 }
@@ -35,8 +35,8 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get ${DDEV_ADDON} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DDEV_ADDON}
+  echo "# ddev add-on get ${DDEV_ADDON} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DDEV_ADDON}
   ddev restart >/dev/null
   health_checks
 }


### PR DESCRIPTION
This pull request includes updates to the installation and testing documentation to reflect changes in command usage for DDEV. The most important changes include updating the installation instructions in the `README.md` and modifying the test scripts to use the new command syntax.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R33): Changed the installation command from `ddev get` to `ddev add-on get` and added a note for users with DDEV versions prior to v1.23.5.

Testing updates:

* [`tests/test.bats`](diffhunk://#diff-a2bb1b04da80b87de17520a6aac3664b1cafdec2b6431697f15968522708a47cL29-R39): Updated the test scripts to use `ddev add-on get` instead of `ddev get` for installing from a directory and from a release.