### PR TITLE
move to OpenForgeProject

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <h1 align="center">ddev-bun</h1>
 </div>
 
-[![tests](https://github.com/Morgy93/ddev-bun/actions/workflows/tests.yml/badge.svg)](https://github.com/Morgy93/ddev-bun/actions/workflows/tests.yml)
+[![tests](https://github.com/OpenForgeProject/ddev-bun/actions/workflows/tests.yml/badge.svg)](https://github.com/OpenForgeProject/ddev-bun/actions/workflows/tests.yml)
 ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
 
 ## What is Bun?
@@ -28,7 +28,7 @@ YouTube: [Bun 1.0 is here](https://www.youtube.com/watch?v=BsnCpESUEqM)
 ## Installation
 
 ```shell
-ddev add-on get Morgy93/ddev-bun
+ddev add-on get OpenForgeProject/ddev-bun
 ddev restart
 ```
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -4,7 +4,7 @@ setup() {
   export TESTDIR=~/tmp/test-bun
   mkdir -p $TESTDIR
   export PROJNAME=test-bun
-  export DDEV_ADDON=Morgy93/ddev-bun
+  export DDEV_ADDON=OpenForgeProject/ddev-bun
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"


### PR DESCRIPTION
This pull request includes changes to update the repository references from `Morgy93/ddev-bun` to `OpenForgeProject/ddev-bun` in various files. 

Repository reference updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L14-R14): Updated the badge URL and installation command to use `OpenForgeProject/ddev-bun` instead of `Morgy93/ddev-bun`.
* [`tests/test.bats`](diffhunk://#diff-a2bb1b04da80b87de17520a6aac3664b1cafdec2b6431697f15968522708a47cL7-R7): Changed the `DDEV_ADDON` environment variable to reference `OpenForgeProject/ddev-bun`.